### PR TITLE
Update ProductAbstractImageEventResourceQueryContainerPlugin.php

### DIFF
--- a/src/Spryker/Zed/ProductImageStorage/Communication/Plugin/Event/ProductAbstractImageEventResourceQueryContainerPlugin.php
+++ b/src/Spryker/Zed/ProductImageStorage/Communication/Plugin/Event/ProductAbstractImageEventResourceQueryContainerPlugin.php
@@ -50,6 +50,7 @@ class ProductAbstractImageEventResourceQueryContainerPlugin extends AbstractPlug
         if ($ids === []) {
             $query->clear();
             $query->clearSelectColumns();
+            $query->innerJoinSpyProductImageSet();
         }
 
         return $query;


### PR DESCRIPTION
If you dont  join imageset-table he can not find SpyProductImageSetTableMap::COL_FK_PRODUCT at 
console event:trigger -r product_abstract_image