### PR TITLE
Fixathon: Add image alt text

### DIFF
--- a/contribution-license-agreement.txt
+++ b/contribution-license-agreement.txt
@@ -1,0 +1,1 @@
+I hereby agree to Spryker's Contribution License Agreement in https://github.com/spryker/product-image-storage/blob/e15b8902b5adcb49d04c001cb372044e5f87db80/CONTRIBUTING.md

--- a/src/Spryker/Shared/ProductImageStorage/Transfer/product_image_storage.transfer.xml
+++ b/src/Spryker/Shared/ProductImageStorage/Transfer/product_image_storage.transfer.xml
@@ -5,7 +5,8 @@
         <property name="idProductImage" type="int"/>
         <property name="externalUrlLarge" type="string"/>
         <property name="externalUrlSmall" type="string"/>
-        <property name="altText" type="string"/>
+        <property name="altTextSmall" type="string"/>
+        <property name="altTextLarge" type="string"/>
     </transfer>
 
     <transfer name="ProductImageSetStorage">

--- a/src/Spryker/Shared/ProductImageStorage/Transfer/product_image_storage.transfer.xml
+++ b/src/Spryker/Shared/ProductImageStorage/Transfer/product_image_storage.transfer.xml
@@ -5,6 +5,7 @@
         <property name="idProductImage" type="int"/>
         <property name="externalUrlLarge" type="string"/>
         <property name="externalUrlSmall" type="string"/>
+        <property name="altText" type="string"/>
     </transfer>
 
     <transfer name="ProductImageSetStorage">


### PR DESCRIPTION
## PR Description
This PR and all included in Core PRs enable Spryker users to set HTML alt text for product images in small and large version.

## Steps before you submit a PR
- Please add tests for the code you add if it's possible.
- Please check out our contribution guide: https://docs.spryker.com/docs/dg/dev/code-contribution-guide.html
- Add a `contribution-license-agreement.txt` file with the following content:
`I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker/product-image-storage/blob/HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH/CONTRIBUTING.md.`

This is a mandatory step to make sure you are aware of the license agreement and agree to it. `HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH` is a hash of the commit you are basing your branch from the master branch. You can take it from commits list of master branch before you submit a PR.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
